### PR TITLE
docs: changed ERD based on new prisma file

### DIFF
--- a/documentation/erd.md
+++ b/documentation/erd.md
@@ -1,117 +1,136 @@
 ```mermaid
 erDiagram
-    genre {
-        bigint id
-        text name
-    }
-    content_rating {
-        bigint id
-        text rating_type
-    }
-    content {
-        bigint id
-        text title
-        timestamp duration
-        date release_date
-        int season
-        bigint quality_id
-        date created_at
-        date updated_at
-    }
-    language {
-        bigint id
-        text language
-    }
-    subtitle {
-        bigint id
-        bigint language_id
-        text content
-    }
-    content_metadata {
-        bigint id
-        bigint title
-        bigint genre_id
-        int rating
-        bigint content_id
-        bigint language_id
-        bigint subtitle_id
-        enum content_type
-        bigint content_rating_id
-        enum age_rating
-        date created_at
-        date updated_at
-    }
-    viewinghistory {
-        bigint id
-        bigint profile_id
-        bigint content_id
-        timestamp watch_date
-        double progress_percentage
-    }
-    watchlist {
-        bigint id
-        bigint profile_id
-        bigint content_id
-    }
-    profile {
-        bigint id
-        bigint account_id
-        text name
-        bigint profile_image
-        date date_of_birth
-        text language
-        date created_at
-        date updated_at
-    }
-    subscription {
-        bigint id
-        date begin_date
-        date end_date
-        bigint account_id
-        bigint subscription_type_id
-        bigint referral_id
-        date created_at
-        date updated_at
-    }
-    subscription_type {
-        bigint id
-        text type
-        int price_in_euro_cents
-    }
-    invoice {
-        bigint id
-        bigint subscription_id
-        enum is_paid
-        date created_at
-        date updated_at
-    }
-    account {
-        bigint id
-        text email
-        text password
-        boolean activated
-        timestamp blocked_until
-        date created_at
-        date updated_at
-    }
-    previous_password_hash {
-        bigint id
-        bigint account_id
-        text password_hash
-        date created_at
+    Account ||--o{ Profile : has
+    Account ||--o{ Subscription : has
+    Account ||--o{ PreviousPasswordHash : has
+    Account ||--o{ Subscription : refers
+
+    Profile ||--o{ ViewingHistory : has
+    Profile ||--o{ Watchlist : has
+
+    Content ||--o{ ContentMetadata : has
+    Content ||--o{ ViewingHistory : "appears in"
+    Content ||--o{ Watchlist : "appears in"
+
+    Genre ||--o{ ContentMetadata : has
+    Language ||--o{ ContentMetadata : has
+    Language ||--o{ Subtitle : has
+    Subtitle ||--o{ ContentMetadata : has
+    ContentRating ||--o{ ContentMetadata : has
+
+    SubscriptionType ||--o{ Subscription : "defines"
+    Subscription ||--o{ Invoice : generates
+
+    Account {
+        BigInt id PK
+        String email
+        String password
+        Boolean activated
+        DateTime blockedUntil
+        DateTime createdAt
+        DateTime updatedAt
     }
 
-    content_metadata }o--|| content : "content_id"
-    content_metadata ||--o{ genre : "genre_id"
-    content_metadata ||--o{ language : "language_id"
-    content_metadata ||--o{ subtitle : "subtitle_id"
-    content_metadata ||--o{ content_rating : "content_rating_id"
-    viewinghistory ||--o{ content : "content_id"
-    viewinghistory ||--o{ profile : "profile_id"
-    watchlist ||--o{ content : "content_id"
-    watchlist ||--o{ profile : "profile_id"
-    subscription ||--o{ account : "account_id"
-    subscription ||--o{ subscription_type : "subscription_type_id"
-    invoice ||--o{ subscription : "subscription_id"
-    account ||--o{ previous_password_hash : "account_id"
+    Profile {
+        BigInt id PK
+        BigInt accountId FK
+        String name
+        BigInt profileImage
+        DateTime dateOfBirth
+        String language
+        DateTime createdAt
+        DateTime updatedAt
+    }
+
+    Content {
+        BigInt id PK
+        String title
+        DateTime duration
+        DateTime releaseDate
+        Int season
+        BigInt qualityId
+        DateTime createdAt
+        DateTime updatedAt
+    }
+
+    ContentMetadata {
+        BigInt id PK
+        BigInt contentId FK
+        BigInt genreId FK
+        BigInt languageId FK
+        BigInt subtitleId FK
+        BigInt contentRatingId FK
+        Int rating
+        ContentType contentType
+        AgeRating ageRating
+        DateTime createdAt
+        DateTime updatedAt
+    }
+
+    Genre {
+        BigInt id PK
+        String name
+    }
+
+    Language {
+        BigInt id PK
+        String language
+    }
+
+    Subtitle {
+        BigInt id PK
+        BigInt languageId FK
+        String content
+    }
+
+    ContentRating {
+        BigInt id PK
+        String ratingType
+    }
+
+    Subscription {
+        BigInt id PK
+        BigInt accountId FK
+        BigInt subscriptionTypeId FK
+        BigInt referralId FK
+        DateTime beginDate
+        DateTime endDate
+        DateTime createdAt
+        DateTime updatedAt
+    }
+
+    SubscriptionType {
+        BigInt id PK
+        String type
+        Int priceInEuroCents
+    }
+
+    Invoice {
+        BigInt id PK
+        BigInt subscriptionId FK
+        PaymentStatus isPaid
+        DateTime createdAt
+        DateTime updatedAt
+    }
+
+    ViewingHistory {
+        BigInt id PK
+        BigInt profileId FK
+        BigInt contentId FK
+        DateTime watchDate
+        Float progressPercentage
+    }
+
+    Watchlist {
+        BigInt id PK
+        BigInt profileId FK
+        BigInt contentId FK
+    }
+
+    PreviousPasswordHash {
+        BigInt id PK
+        BigInt accountId FK
+        String passwordHash
+        DateTime createdAt
+    }
 ```


### PR DESCRIPTION
This pull request includes significant updates to the entity-relationship diagram (ERD) in the `documentation/erd.md` file. The changes involve a complete overhaul of the entities and their relationships to better reflect the current data model.

Key changes include:

* **New Entities and Relationships:**
  * Added new entities such as `Account`, `Profile`, `Subscription`, `Content`, `ContentMetadata`, `Genre`, `Language`, `Subtitle`, `ContentRating`, `SubscriptionType`, `Invoice`, `ViewingHistory`, `Watchlist`, and `PreviousPasswordHash`. Each entity includes relevant fields and primary keys.
  * Established relationships between these entities to accurately represent the data model, including "has", "refers", "appears in", "defines", and "generates" relationships.

* **Removed Old Entities and Relationships:**
  * Removed outdated entities such as `genre`, `content_rating`, `content`, `language`, `subtitle`, `content_metadata`, `viewinghistory`, `watchlist`, `profile`, `subscription`, `subscription_type`, `invoice`, `account`, and `previous_password_hash`.
  * Removed old relationships that no longer apply to the updated data model.

These changes ensure that the ERD accurately reflects the current structure and relationships within the database