### PR TITLE
chore: update DATABASE_URL in .env.example and docker-compose for consistent database connection and add trusted origins to auth config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,6 @@
 POSTGRES_USER=netflix
 POSTGRES_PASSWORD=example
 POSTGRES_DB=netflix
-DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB} # This is the URL of the database
 
 # This is the environment variables for the better-auth server
 BETTER_AUTH_SECRET=nRUcLYsAV7p2cjtcktzWluLcqh7yMuGG # This is a random secret key

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       - '3000:3000'
     environment:
       - NODE_ENV=production
-      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB}
+      - DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET}
       - BETTER_AUTH_URL=${BETTER_AUTH_URL}
     restart: always

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -18,6 +18,7 @@ export default function page() {
     <div>
       <h1 className="text-xl font-bold">
         Welcome to the dashboard,
+        {' '}
         {session.user.name}
         !
       </h1>

--- a/src/components/dynamic-table.tsx
+++ b/src/components/dynamic-table.tsx
@@ -435,6 +435,7 @@ export default function DynamicTable({
                   {Math.min(currentPage * itemsPerPage, totalItems)}
                   {' '}
                   of
+                  {' '}
                   {totalItems}
                   {' '}
                   entries

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -23,6 +23,8 @@ export const auth = betterAuth({
     },
   },
 
+  trustedOrigins: ['http://localhost:3000'],
+
   plugins: [jwt(), bearer()],
 });
 

--- a/src/lib/classes/authentication-service.ts
+++ b/src/lib/classes/authentication-service.ts
@@ -1,6 +1,5 @@
 import type { NextRequest } from 'next/server';
 
-import { Role } from '@prisma/client';
 import { headers } from 'next/headers';
 
 import { logger } from '@/lib/pinologger';

--- a/src/lib/classes/authentication-service.ts
+++ b/src/lib/classes/authentication-service.ts
@@ -17,31 +17,31 @@ export abstract class AuthenticationService {
    */
   static async getSession(headers: Headers): Promise<Session | null> {
     const session = await auth.api.getSession({ headers });
-    // return session;
+    return session;
 
-    // mock Authentication
-    return {
-      user: {
-        id: '1',
-        email: '1',
-        name: '1',
-        role: Role.JUNIOR,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        emailVerified: true,
-      },
-      session: {
-        id: '1',
-        expiresAt: new Date(),
-        userId: '1',
-        createdAt: new Date(),
-        updatedAt: new Date(),
-        token: 'adwald',
-        ipAddress: '127.0.0.1',
-        userAgent:
-          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.101.76 Safari/537.36',
-      },
-    };
+    // // mock Authentication
+    // return {
+    //   user: {
+    //     id: '1',
+    //     email: '1',
+    //     name: '1',
+    //     role: Role.JUNIOR,
+    //     createdAt: new Date(),
+    //     updatedAt: new Date(),
+    //     emailVerified: true,
+    //   },
+    //   session: {
+    //     id: '1',
+    //     expiresAt: new Date(),
+    //     userId: '1',
+    //     createdAt: new Date(),
+    //     updatedAt: new Date(),
+    //     token: 'adwald',
+    //     ipAddress: '127.0.0.1',
+    //     userAgent:
+    //       'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.101.76 Safari/537.36',
+    //   },
+    // };
   }
 
   /**

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,13 +1,16 @@
-/* eslint-disable node/no-process-env */
 import { z } from 'zod';
+
+/* eslint-disable node/no-process-env */
 
 // Server-side only schema
 const envSchema = z.object({
   NODE_ENV: z.string().default('development'),
   PORT: z.coerce.number().default(3000),
-  DATABASE_URL: z.string(),
   BETTER_AUTH_SECRET: z.string(),
   BETTER_AUTH_URL: z.string(),
+  POSTGRES_USER: z.string(),
+  POSTGRES_PASSWORD: z.string(),
+  POSTGRES_DB: z.string(),
 });
 
 // Type for our env


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and authentication setup. The most important changes involve updating the database URL in the environment and Docker Compose files, and adding a trusted origin in the authentication configuration.

Configuration updates:

* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL7): Removed the `DATABASE_URL` environment variable.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R8): Updated the `DATABASE_URL` to use the `postgres` hostname instead of `localhost`.

Authentication improvements:

* [`src/lib/auth.ts`](diffhunk://#diff-486994d46df34c53636a706a1ca6a05bd8261ccde47463ea2c739af56f090b78R26-R27): Added `http://localhost:3000` to the `trustedOrigins` in the `betterAuth` configuration.